### PR TITLE
Create unique filenames for each run with logpyle

### DIFF
--- a/y3prediction/prediction.py
+++ b/y3prediction/prediction.py
@@ -194,7 +194,7 @@ def main(ctx_factory=cl.create_some_context,
     comm.Barrier()
 
     logmgr = initialize_logmgr(use_logmgr,
-        filename=logname, mode="wo", mpi_comm=comm)
+        filename=logname, mode="wu", mpi_comm=comm)
 
     if use_profiling:
         queue = cl.CommandQueue(cl_ctx,


### PR DESCRIPTION
Unique (u) mode adds a timestamp to the filename automatically, synchronized across ranks.

before:  `prediction-rank0.sqlite`, `prediction-rank1.sqlite`, ...
after: `prediction-rank0-20230220-234917.sqlite`, `prediction-rank1-20230220-234917.sqlite`, ...



cc: https://github.com/illinois-ceesd/drivers_y2-prediction/pull/24