### PR TITLE
Remove unnecessary `wall_penalty_amount` from `add_interface_boundaries_no_grad`

### DIFF
--- a/y3prediction/prediction.py
+++ b/y3prediction/prediction.py
@@ -336,7 +336,6 @@ def update_coupled_boundaries(
             wall_boundaries=wall_boundaries,
             interface_noslip=interface_noslip,
             #interface_radiation,
-            wall_penalty_amount=wall_penalty_amount,
             quadrature_tag=quadrature_tag,
             comm_tag=comm_tag)
 


### PR DESCRIPTION
For compatibility with illinois-ceesd/mirgecom#928 (the penalty amount is only needed for the with-grad version).