### PR TITLE
Fix zeros_like issue when running numpy context

### DIFF
--- a/y3prediction/actii_y3.py
+++ b/y3prediction/actii_y3.py
@@ -543,7 +543,7 @@ class InitACTII:
             zpos = x_vec[2]
         actx = xpos.array_context
 
-        zeros = actx.zeros_like(xpos)
+        zeros = actx.np.zeros_like(xpos)
         ones = zeros + 1.0
 
         # get the current mesh conditions
@@ -734,7 +734,7 @@ class InitACTII:
             zpos = x_vec[2]
         actx = xpos.array_context
 
-        zeros = actx.zeros_like(xpos)
+        zeros = actx.np.zeros_like(xpos)
         ones = zeros + 1.0
 
         # get the current mesh conditions


### PR DESCRIPTION
Must use `actx.np.zeros_like` _not_ just `actx.zeros_like` 