### PR TITLE
improve bc selection and fix a bug

### DIFF
--- a/smoke_test/run_params.yaml
+++ b/smoke_test/run_params.yaml
@@ -30,3 +30,5 @@ integrator: euler
 #integrator: lsrk54
 #health_pres_min: 2828
 #health_pres_max: 274259
+use_inflow_boundary: False
+use_outflow_boundary: False

--- a/y3prediction/prediction.py
+++ b/y3prediction/prediction.py
@@ -1496,8 +1496,6 @@ def main(actx_class,
     def check_boundary(boundary, name):
         try:
             force_evaluation(actx, actx.thaw(dcoll.nodes(boundary)))
-            if rank == 0:
-                print(f"Found boundary {name} in fluid domain")
         except ValueError:
             if rank == 0:
                 print(f"Could not find boundary named {name} in fluid domain,",

--- a/y3prediction/prediction.py
+++ b/y3prediction/prediction.py
@@ -1502,7 +1502,9 @@ def main(actx_class,
                        "boundary type will be unused")
             return False
 
-        return True
+       if rank == 0:
+           print(f"Found boundary {name} in fluid domain")
+       return True
 
     if use_outflow_boundary:
         use_outflow_boundary = check_boundary(outflow_bnd, "outflow")

--- a/y3prediction/prediction.py
+++ b/y3prediction/prediction.py
@@ -2337,10 +2337,10 @@ def main(actx_class,
 
     else:
         # Set the current state from time 0
-        #target_cv = restart_cv
-        #target_av_smu = restart_av_smu
-        #target_av_sbeta = restart_av_sbeta
-        #target_av_skappa = restart_av_skappa
+        target_cv = restart_cv
+        target_av_smu = restart_av_smu
+        target_av_sbeta = restart_av_sbeta
+        target_av_skappa = restart_av_skappa
 
         target_fluid_state = restart_fluid_state
 

--- a/y3prediction/prediction.py
+++ b/y3prediction/prediction.py
@@ -1613,7 +1613,6 @@ def main(actx_class,
 
         smooth_neumann = NeumannDiffusionBoundary(0)
 
-        # I can't call this function here?
         fluid_smoothness_boundaries = assign_fluid_boundaries(
             outflow=smooth_neumann,
             inflow=smooth_neumann,
@@ -3814,10 +3813,13 @@ def main(actx_class,
         if use_av > 0:
             # regular boundaries for smoothness mu
             smooth_neumann = NeumannDiffusionBoundary(0)
-            fluid_av_boundaries = {
-                flow_bnd.domain_tag: smooth_neumann,
-                wall_bnd.domain_tag: smooth_neumann,
-            }
+            fluid_av_boundaries = assign_fluid_boundaries(
+                outflow=smooth_neumann,
+                inflow=smooth_neumann,
+                injection=smooth_neumann,
+                flow=smooth_neumann,
+                wall=smooth_neumann,
+                interface=smooth_neumann)
 
             if use_wall:
                 from grudge.discretization import filter_part_boundaries
@@ -3826,9 +3828,6 @@ def main(actx_class,
                      for dd_bdry in filter_part_boundaries(
                          dcoll, volume_dd=dd_vol_fluid,
                          neighbor_volume_dd=dd_vol_wall)})
-            else:
-                fluid_av_boundaries.update({
-                    interface_bnd.domain_tag: smooth_neumann})
 
             # av mu
             av_smu_rhs = (

--- a/y3prediction/prediction.py
+++ b/y3prediction/prediction.py
@@ -1523,7 +1523,8 @@ def main(actx_class,
             use_inflow_boundary and use_flow_boundary):
         error_message = \
             "Invalid boundary configuration, inflow/outflow with flow:"
-        raise RuntimeError(error_message)
+        from mirgecom.simutil import SimulationConfigurationError
+        raise SimulationConfigurationError(error_message)
 
     # setup basic boundary conditions
     if noslip:

--- a/y3prediction/prediction.py
+++ b/y3prediction/prediction.py
@@ -724,35 +724,18 @@ def main(actx_class,
         print(f"\tdimension = {dim}")
         print(f"\tTime integration {integrator}")
         print("   Boundary Conditions:")
-        if use_outflow_boundary:
-            print("\tChecking for outflow boundary in mesh")
-        else:
-            print("\tIgnoring outflow boundary in mesh")
-
-        if use_inflow_boundary:
-            print("\tChecking for inflow boundary in mesh")
-        else:
-            print("\tIgnoring inflow boundary in mesh")
-
-        if use_flow_boundary:
-            print("\tChecking for flow boundary in mesh")
-        else:
-            print("\tIgnoring flow boundary in mesh")
-
-        if use_injection_boundary:
-            print("\tChecking for injection boundary in mesh")
-        else:
-            print("\tIgnoring injection boundary in mesh")
-
-        if use_wall_boundary:
-            print("\tChecking for wall boundary in mesh")
-        else:
-            print("\tIgnoring wall boundary in mesh")
-
-        if use_interface_boundary:
-            print("\tChecking for interface boundary in mesh")
-        else:
-            print("\tIgnoring interface boundary in mesh")
+        bndry_config = { "outflow": use_outflow_boundary,
+                                     "inflow": use_inflow_boundary,
+                                     "flow": use_flow_boundary,
+                                     "injection": use_injection_boundary,
+                                     "wall": use_wall_boundary,
+                                     "interface": use_interface_boundary}
+        bnd_msg = ""
+        for bname, bsetting in bndry_config.items():
+              msg_action = "Checking for" if bsetting else "Ignoring"
+              bnd_msg = bnd_msg + f"\t{msg_action} {bname} boundary in mesh."
+         if rank == 0:
+              print(bnd_msg)
 
         if noslip:
             print("\tFluid wall boundary conditions are noslip for veloctiy")

--- a/y3prediction/prediction.py
+++ b/y3prediction/prediction.py
@@ -724,18 +724,18 @@ def main(actx_class,
         print(f"\tdimension = {dim}")
         print(f"\tTime integration {integrator}")
         print("   Boundary Conditions:")
-        bndry_config = { "outflow": use_outflow_boundary,
-                                     "inflow": use_inflow_boundary,
-                                     "flow": use_flow_boundary,
-                                     "injection": use_injection_boundary,
-                                     "wall": use_wall_boundary,
-                                     "interface": use_interface_boundary}
+        bndry_config = {"outflow": use_outflow_boundary,
+                        "inflow": use_inflow_boundary,
+                        "flow": use_flow_boundary,
+                        "injection": use_injection_boundary,
+                        "wall": use_wall_boundary,
+                        "interface": use_interface_boundary}
         bnd_msg = ""
         for bname, bsetting in bndry_config.items():
-              msg_action = "Checking for" if bsetting else "Ignoring"
-              bnd_msg = bnd_msg + f"\t{msg_action} {bname} boundary in mesh."
-         if rank == 0:
-              print(bnd_msg)
+            msg_action = "Checking for" if bsetting else "Ignoring"
+            bnd_msg = bnd_msg + f"\t{msg_action} {bname} boundary in mesh."
+        if rank == 0:
+            print(bnd_msg)
 
         if noslip:
             print("\tFluid wall boundary conditions are noslip for veloctiy")
@@ -1485,9 +1485,9 @@ def main(actx_class,
                        "boundary type will be unused")
             return False
 
-       if rank == 0:
-           print(f"Found boundary {name} in fluid domain")
-       return True
+        if rank == 0:
+            print(f"Found boundary {name} in fluid domain")
+        return True
 
     if use_outflow_boundary:
         use_outflow_boundary = check_boundary(outflow_bnd, "outflow")


### PR DESCRIPTION
Improve the selection for boundary conditions.

Specify certain tags/labels that can be given to boundaries in the mesh generation such that they get the appropriate boundary conditions applied by the driver.

inflow
outflow
injection
wall
flow
interface

flow boundaries are prescribed from target state and exist to minimize the number of unique boundary tags to increase compilation speed and timestep performance. they cannot exist when inflow or outflow are enabled. injection has a dual purposed, either wall or prescribed boundary.

The code will search for a particular tag by trying to retrieve the nodes from the dd. If detected, then the user can supply the proper boundary condition for that tag and pass it to the helper function, apply_fluid_boundary.

To preserve legacy behavior, checking for inflow and outflow boundaries are disabled by default, as they exist in every mesh created to date.