### PR TITLE
Debug y5 tip

### DIFF
--- a/test/test_limiter.py
+++ b/test/test_limiter.py
@@ -401,16 +401,17 @@ def test_positivity_preserving_limiter_multi(actx_factory, order, dim, nspecies,
 
     print(f"{actx.to_numpy(limited_mass_frac)=}")
     # check minimum and maximum
+    spec_tol = 1e-16
     for i in range(nspecies):
-        assert actx.to_numpy(actx.np.min(limited_mass_frac[i])) > 0.0 - 1.e-11
-        assert actx.to_numpy(actx.np.min(limited_mass_frac[i])) < 1.0 + 1.e-11
+        assert actx.to_numpy(actx.np.min(limited_mass_frac[i])) >= 0.0
+        assert actx.to_numpy(actx.np.min(limited_mass_frac[i])) < 1.0 + spec_tol
 
     # check y sums to 1
     y_sum = actx.np.zeros_like(limited_cv.mass)
     for i in range(nspecies):
         y_sum = y_sum + limited_mass_frac[i]
     y_sum_m1 = actx.np.abs(y_sum - 1.0)
-    assert actx.to_numpy(actx.np.max(y_sum_m1)) < 1e-11
+    assert actx.to_numpy(actx.np.max(y_sum_m1)) < nspecies*spec_tol
 
     # check pressure positivity
     assert actx.to_numpy(actx.np.min(pressure_limited)) > 0.

--- a/test/test_limiter.py
+++ b/test/test_limiter.py
@@ -409,6 +409,8 @@ def test_positivity_preserving_limiter_multi(actx_factory, order, dim, nspecies,
     y_sum = actx.np.zeros_like(limited_cv.mass)
     for i in range(nspecies):
         y_sum = y_sum + limited_mass_frac[i]
+    y_sum_m1 = actx.np.abs(y_sum - 1.0)
+    assert actx.to_numpy(actx.np.max(y_sum_m1)) < 1e-11
 
     # check pressure positivity
     assert actx.to_numpy(actx.np.min(pressure_limited)) > 0.

--- a/y3prediction/prediction.py
+++ b/y3prediction/prediction.py
@@ -848,8 +848,10 @@ def limit_fluid_state_lv(dcoll, cv, temperature_seed, entropy_min,
             aux = aux + spec_lim[i]
             sum_theta_y = sum_theta_y + actx.np.abs(spec_lim[i])
             # only rebalance where species limiting actually occured
+        for i in range(0, nspecies):
             spec_lim[i] = actx.np.where(actx.np.greater(balance_spec, 0.),
                                         spec_lim[i]/aux, spec_lim[i])
+
         #spec_lim = spec_lim/aux
 
         # tseed is the best guess at a reasonable temperature after the limiting

--- a/y3prediction/prediction.py
+++ b/y3prediction/prediction.py
@@ -827,7 +827,8 @@ def limit_fluid_state_lv(dcoll, cv, temperature_seed, entropy_min,
                 mmax_i = op.elementwise_max(
                     dcoll, dd, cv_update_rho.species_mass_fractions[i])
                 mmax = 1.0
-                cell_avgs = actx.np.where(actx.np.less(cell_avgs, mmax), cell_avgs, mmax)
+                cell_avgs = actx.np.where(actx.np.less(cell_avgs, mmax),
+                                          cell_avgs, mmax)
                 _theta = actx.np.maximum(
                     _theta,
                     actx.np.where(actx.np.greater(mmax_i - toler, mmax),
@@ -839,9 +840,10 @@ def limit_fluid_state_lv(dcoll, cv, temperature_seed, entropy_min,
                                              1.0, balance_spec)
                 #print(f"species {i}, {_theta=}")
                 # apply the limiting to all species equally
-                spec_lim[i] = (cv_update_rho.species_mass_fractions[i] +
-                               theta_spec[i]*(
-                                   cell_avgs - cv_update_rho.species_mass_fractions[i]))
+                spec_lim[i] = \
+                    (cv_update_rho.species_mass_fractions[i]
+                     + theta_spec[i]*(cell_avgs
+                                      - cv_update_rho.species_mass_fractions[i]))
 
         if hammer_species:
             # limit the species mass fraction sum to 1.0
@@ -849,7 +851,7 @@ def limit_fluid_state_lv(dcoll, cv, temperature_seed, entropy_min,
             sum_theta_y = actx.np.zeros_like(cv_update_rho.mass)
             zeros_spec = actx.np.zeros_like(cv_update_rho.mass)
             for i in range(nspecies):
-                spec_lim[i] = actx.np.where(actx.np.less(spec_lim[i], zeros_spec), 
+                spec_lim[i] = actx.np.where(actx.np.less(spec_lim[i], zeros_spec),
                                             zeros_spec, spec_lim[i])
 
             # spec_lim = actx.np.where(spec_lim > 0., spec_lim, zero_spec)
@@ -6575,7 +6577,7 @@ def main(actx_class, restart_filename=None, target_filename=None,
             local_max = actx.np.max(ysum)
             local_min = actx.np.min(ysum)
             global_min = vol_min(dd_vol_fluid, ysum)
-            gloabl_max = vol_max(dd_vol_fluid, ysum)
+            global_max = vol_max(dd_vol_fluid, ysum)
             global_min_loc = vol_min_loc(dd_vol_fluid, ysum)
             global_max_loc = vol_max_loc(dd_vol_fluid, ysum)
             if rank == 0:
@@ -6588,7 +6590,6 @@ def main(actx_class, restart_filename=None, target_filename=None,
             report_violators(ysum, 1.-sum_tol, 1.+sum_tol)
 
         return health_error
-
 
     def my_health_check(fluid_state, wall_temperature):
         health_error = False


### PR DESCRIPTION
This change set appears to resolve the issue where there is spurious mass generation near a boundary in the Y5 inlet tip test case. The awful things it does:

- Adds a test that limited species mass fractions (Y) sum to 1 (great)
- Tightens the tolerances in the tests  that Y is in [0, 1]. (great)
- Disables the freaky deeky average leaky Y limiting. (hrm)
- Fixes the limiter snippet that wasn't actually setting sum(Y) = 1 (great)
- Adds a giant hammer in the limiter to bang Y in to [0, 1] no matter what (awfulish)
- Adds a pre-limiting state check to driver to ensure that the mass fractions are sane to very tight tolerance (great)