### PR TITLE
Debug species drift

### DIFF
--- a/test/test_limiter.py
+++ b/test/test_limiter.py
@@ -401,14 +401,19 @@ def test_positivity_preserving_limiter_multi(actx_factory, order, dim, nspecies,
 
     print(f"{actx.to_numpy(limited_mass_frac)=}")
     # check minimum and maximum
+    spec_tol_min = 1e-16
+    spec_tol_max = 2e-16
     for i in range(nspecies):
-        assert actx.to_numpy(actx.np.min(limited_mass_frac[i])) > 0.0 - 1.e-11
-        assert actx.to_numpy(actx.np.min(limited_mass_frac[i])) < 1.0 + 1.e-11
+        assert actx.to_numpy(actx.np.min(limited_mass_frac[i])) > -spec_tol_min
+        assert actx.to_numpy(actx.np.max(limited_mass_frac[i])) < 1.0 + spec_tol_max
 
     # check y sums to 1
+    spec_sum_tol = 1e-15
     y_sum = actx.np.zeros_like(limited_cv.mass)
     for i in range(nspecies):
         y_sum = y_sum + limited_mass_frac[i]
+    y_sum_m1 = actx.np.abs(y_sum - 1.0)
+    assert actx.to_numpy(actx.np.max(y_sum_m1)) < spec_sum_tol
 
     # check pressure positivity
     assert actx.to_numpy(actx.np.min(pressure_limited)) > 0.


### PR DESCRIPTION
Species drift on noslip boundary in Y5 appears to be coming from axisymmetric source terms.  This change set *does not* fix that problem, but it does:

- Add/fix tests of limiter to check that Y is in [0,1] and sums to 1.0
- Fixes a couple of foibles in the Lv-limiter which caused the above tests to fail
   - Looping error where sum(Y) was modified for limited Y's
   - Limited energy omission after species limiting
   - Avoid mixture treatment when transporting passive scalars
- Adds a check and hammer function to force Y into the proper range as a temporary bandaid
 