### PR TITLE
[NOMERGE] Sanity check CI time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,6 @@ jobs:
             python -m pip install wheel
             python -m pip install pylint pyyaml
 
-            pylint setup.py driver.py y3prediction/*.py
-
         - name: Pytest
           run: |
             source emirge/config/activate_env.sh


### PR DESCRIPTION
#91 CI took a while, and `main` CI is borked at the moment due to pylint. Testing `main`-ish CI here instead.